### PR TITLE
Additional master slave config values

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,15 @@ mesos_additional_configs: []
   # For example:
   # - name: FOO
   #   value: bar
+
+# Additional configurations for master
+mesos_master_additional_configs: []
+  # For example:
+  # - name: FOO
+  #   value: bar
+
+# Additional configurations for slave
+mesos_slave_additional_configs: []
+  # For example:
+  # - name: FOO
+  #   value: bar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,4 +11,4 @@
 - include: RedHat.yml
   when: ansible_os_family == "RedHat"
 
-- include: mesos.yml
+- include: mesos.yml tags=configuration

--- a/templates/conf-mesos-master.j2
+++ b/templates/conf-mesos-master.j2
@@ -3,3 +3,8 @@
 export MESOS_QUORUM="{{ mesos_quorum }}"
 export MESOS_WORK_DIR="{{ mesos_work_dir }}"
 export MESOS_PORT="{{ mesos_master_port }}"
+
+# Additional configs
+{% for config_item in mesos_master_additional_configs %}
+export MESOS_{{config_item.name}}={{config_item.value}}
+{% endfor %}

--- a/templates/conf-mesos-master.j2
+++ b/templates/conf-mesos-master.j2
@@ -4,7 +4,7 @@ export MESOS_QUORUM="{{ mesos_quorum }}"
 export MESOS_WORK_DIR="{{ mesos_work_dir }}"
 export MESOS_PORT="{{ mesos_master_port }}"
 
-# Additional configs
+# Additional config values
 {% for config_item in mesos_master_additional_configs %}
-export MESOS_{{config_item.name}}={{config_item.value}}
+export {{config_item.name}}={{config_item.value}}
 {% endfor %}

--- a/templates/conf-mesos-slave.j2
+++ b/templates/conf-mesos-slave.j2
@@ -5,3 +5,13 @@ export MESOS_CONTAINERIZERS="{{ mesos_containerizers }}"
 export MESOS_EXECUTOR_REGISTRATION_TIMEOUT="{{ mesos_executor_timeout }}"
 export MESOS_PORT="{{ mesos_slave_port }}"
 export MESOS_WORK_DIR="{{ mesos_work_dir }}"
+
+# Additional configs
+{% for config_item in mesos_slave_additional_configs %}
+export MESOS_{{config_item.name}}={{config_item.value}}
+{% endfor %}
+
+{% for config_item in mesos_slave_additional_env %}
+export {{config_item.name}}={{config_item.value}}
+{% endfor %}
+

--- a/templates/conf-mesos-slave.j2
+++ b/templates/conf-mesos-slave.j2
@@ -6,12 +6,8 @@ export MESOS_EXECUTOR_REGISTRATION_TIMEOUT="{{ mesos_executor_timeout }}"
 export MESOS_PORT="{{ mesos_slave_port }}"
 export MESOS_WORK_DIR="{{ mesos_work_dir }}"
 
-# Additional configs
+# Additional config values
 {% for config_item in mesos_slave_additional_configs %}
-export MESOS_{{config_item.name}}={{config_item.value}}
-{% endfor %}
-
-{% for config_item in mesos_slave_additional_env %}
 export {{config_item.name}}={{config_item.value}}
 {% endfor %}
 


### PR DESCRIPTION
### Short description:

Currently one cannot configure custom values (not supported by the ansible template)
in both the mesos slave nor master conf files.

This PR proposes a flexible extension that allows the user to define custom values using a dictionary variable in both cases.
