### PR TITLE
Enable apt pinning and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ mesos_version: "1.0.1"
 
 # Debian
 mesos_package_version: "2.0.93"
-mesosphere_apt_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
 mesos_os_distribution: "{{ ansible_distribution | lower }}"
 mesos_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
-mesos_apt_package: "mesos={{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}"
+mesos_apt_url: "http://{{ mesos_repo_host }}/{{ ansible_distribution | lower }}"
+mesos_package_full_version: "{{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}"
+mesos_apt_package: "mesos={{ mesos_package_full_version }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
 epel_repo: "https://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,16 +2,18 @@
 mesos_install_mode: "master" # {master|slave|master-slave}
 mesos_version: "1.1.0"
 
+mesos_repo_host: repo.mesosphere.com
+
 # Debian
 mesos_package_version: "2.0.107"
-mesosphere_apt_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
+mesosphere_apt_url: "http://{{ mesos_repo_host }}/{{ ansible_distribution | lower }}"
 mesos_os_distribution: "{{ ansible_distribution | lower }}"
 mesos_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
 mesos_apt_package: "mesos={{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
 epel_repo: "https://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"
-mesosphere_yum_repo: "https://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
+mesosphere_yum_repo: "https://{{ mesos_repo_host }}/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 
 # conf file settings
 mesos_cluster_name: "mesos_cluster"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,10 +6,11 @@ mesos_repo_host: repo.mesosphere.com
 
 # Debian
 mesos_package_version: "2.0.107"
-mesosphere_apt_url: "http://{{ mesos_repo_host }}/{{ ansible_distribution | lower }}"
 mesos_os_distribution: "{{ ansible_distribution | lower }}"
 mesos_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
-mesos_apt_package: "mesos={{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}"
+mesos_package_full_version: "{{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}"
+mesosphere_apt_url: "http://{{ mesos_repo_host }}/{{ ansible_distribution | lower }}"
+mesos_apt_package: "mesos={{ mesos_package_full_version }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
 epel_repo: "https://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -5,6 +5,12 @@
 - name: Add mesosphere repo
   apt_repository: repo='deb {{ mesosphere_apt_url }} {{ ansible_distribution_release | lower }} main' state=present update_cache=yes
 
+- name: Pin Mesos version
+  template:
+    src: mesos.pref.j2
+    dest: /etc/apt/preferences.d/mesos.pref
+  when: mesos_apt_pin_priority
+
 - name: Install Debian OS packages
   apt: pkg={{ item }} state=present update_cache=yes cache_valid_time=3600
   with_items:

--- a/templates/mesos.pref.j2
+++ b/templates/mesos.pref.j2
@@ -1,3 +1,3 @@
 Package: mesos
-Pin: version {{ mesos_version }}-{{ mesos_package_version }}
+Pin: version {{ mesos_package_full_version }}
 Pin-Priority: {{ mesos_apt_pin_priority }}

--- a/templates/mesos.pref.j2
+++ b/templates/mesos.pref.j2
@@ -1,0 +1,3 @@
+Package: mesos
+Pin: version {{ mesos_version }}-{{ mesos_package_version }}
+Pin-Priority: {{ mesos_apt_pin_priority }}


### PR DESCRIPTION
Add APT pinning for Mesos, so we can safely run an upgrade of all the packages on a node running Mesos

Also allow specifying a different upstream server for updates